### PR TITLE
Feature implementation from commits c102f54..3b4407c

### DIFF
--- a/changelog/unreleased/ghsa-3m86-c9x3-vwm9.toml
+++ b/changelog/unreleased/ghsa-3m86-c9x3-vwm9.toml
@@ -1,0 +1,2 @@
+type = "security"
+message = "Fix permission check for creating a new API-token. See [GHSA-3m86-c9x3-vwm9](https://github.com/Graylog2/graylog2-server/security/advisories/GHSA-3m86-c9x3-vwm9) for details."

--- a/changelog/unreleased/issue-22781.toml
+++ b/changelog/unreleased/issue-22781.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Display delete button completely in saved searches overview."
+
+issues = ["22781"]
+pulls = ["22929"]

--- a/changelog/unreleased/pr-22839.toml
+++ b/changelog/unreleased/pr-22839.toml
@@ -1,0 +1,6 @@
+type = "f"
+message = "Fixing timerange calculation for 'to' in DatePicker depending on 'from:All time' selection."
+
+pulls = ["22839"]
+issues = ["22430"]
+

--- a/changelog/unreleased/pr-22882.toml
+++ b/changelog/unreleased/pr-22882.toml
@@ -1,0 +1,4 @@
+type = "a"
+message = "Adding Text/Markdown widget to available search/dashboard widgets."
+
+pulls = ["22882"]

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -402,7 +402,7 @@
             <dependency>
                 <groupId>io.opentelemetry.instrumentation</groupId>
                 <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-                <version>${opentelemetry.version}</version>
+                <version>${opentelemetry-instrumentation.version}</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.msk</groupId>

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -180,7 +180,7 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
 
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
-        try (var stream = eventDefinitionService.streamAll()) {
+        try (final var stream = eventDefinitionService.streamAll()) {
             return stream
                     .filter(ed -> ed.config().isContentPackExportable())
                     .map(this::createExcerpt)

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
@@ -18,6 +18,7 @@ package org.graylog.events.contentpack.facade;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.inject.Inject;
 import org.graylog.events.contentpack.entities.NotificationEntity;
 import org.graylog.events.notifications.DBNotificationService;
 import org.graylog.events.notifications.NotificationDto;
@@ -37,8 +38,6 @@ import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Inject;
 
 import java.util.Map;
 import java.util.Optional;
@@ -125,8 +124,10 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
 
     @Override
     public Set<EntityExcerpt> listEntityExcerpts() {
-        return notificationService.streamAll()
-                .map(this::createExcerpt)
-                .collect(Collectors.toSet());
+        try (final var stream = notificationService.streamAll()) {
+            return stream
+                    .map(this::createExcerpt)
+                    .collect(Collectors.toSet());
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/DBNotificationService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/DBNotificationService.java
@@ -16,10 +16,11 @@
  */
 package org.graylog.events.notifications;
 
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import jakarta.inject.Inject;
 import org.bson.conversions.Bson;
 import org.graylog.security.entities.EntityOwnershipService;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.pagination.MongoPaginationHelper;
@@ -86,6 +87,7 @@ public class DBNotificationService {
         return mongoUtils.getById(id);
     }
 
+    @MustBeClosed
     public Stream<NotificationDto> streamAll() {
         return stream(collection.find());
     }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
@@ -17,7 +17,6 @@
 package org.graylog.events.processor;
 
 import com.google.errorprone.annotations.MustBeClosed;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Updates;
 import jakarta.inject.Inject;
@@ -27,6 +26,7 @@ import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.plugins.views.search.searchfilters.db.SearchFiltersReFetcher;
 import org.graylog.plugins.views.search.searchfilters.model.UsedSearchFilter;
 import org.graylog.security.entities.EntityOwnershipService;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.entities.EntityScopeService;
@@ -227,9 +227,11 @@ public class DBEventDefinitionService {
     }
 
     public List<EventDefinitionDto> getByIds(Collection<String> ids) {
-        return MongoUtils.stream(collection.find(MongoUtils.stringIdsIn(ids)))
-                .map(this::getEventDefinitionWithRefetchedFilters)
-                .toList();
+        try (final var stream = stream(collection.find(MongoUtils.stringIdsIn(ids)))) {
+            return stream
+                    .map(this::getEventDefinitionWithRefetchedFilters)
+                    .toList();
+        }
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/mongodb/MongoDbPipelineService.java
@@ -149,7 +149,9 @@ public class MongoDbPipelineService implements PipelineService {
 
     @Override
     public Set<PipelineDao> loadByIds(Set<String> pipelineIds) {
-        return MongoUtils.stream(collection.find(stringIdsIn(pipelineIds))).collect(Collectors.toSet());
+        try (final var stream = MongoUtils.stream(collection.find(stringIdsIn(pipelineIds)))) {
+            return stream.collect(Collectors.toSet());
+        }
     }
 
     public long count(Bson filter) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/SidecarService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/services/SidecarService.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.sidecar.services;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.FindOneAndReplaceOptions;
 import com.mongodb.client.model.IndexOptions;
@@ -149,6 +150,7 @@ public class SidecarService {
         }
     }
 
+    @MustBeClosed
     private Stream<Sidecar> streamAll() {
         return MongoUtils.stream(collection.find());
     }
@@ -313,6 +315,7 @@ public class SidecarService {
                 .collect(Collectors.toList());
     }
 
+    @MustBeClosed
     public Stream<Sidecar> findByTagsAndOS(Collection<String> tags, String os) {
         return MongoUtils.stream(collection.find(
                 and(

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -35,7 +35,6 @@ import org.graylog.plugins.views.migrations.V20200730000000_AddGl2MessageIdField
 import org.graylog.plugins.views.migrations.V20240605120000_RemoveUnitFieldFromSearchDocuments;
 import org.graylog.plugins.views.migrations.V20240626143000_CreateDashboardsView;
 import org.graylog.plugins.views.migrations.V20240704100700_DashboardAddLastUpdated;
-import org.graylog.plugins.views.search.jobs.periodical.SearchJobStateCleanupOnStartup;
 import org.graylog.plugins.views.providers.ExportBackendProvider;
 import org.graylog.plugins.views.providers.QuerySuggestionsProvider;
 import org.graylog.plugins.views.search.SearchRequirements;
@@ -60,6 +59,7 @@ import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 import org.graylog.plugins.views.search.filter.StreamCategoryFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog.plugins.views.search.jobs.periodical.SearchJobStateCleanupOnStartup;
 import org.graylog.plugins.views.search.jobs.periodical.SearchJobStateCleanupPeriodical;
 import org.graylog.plugins.views.search.querystrings.LastUsedQueryStringsService;
 import org.graylog.plugins.views.search.querystrings.MongoLastUsedQueryStringsService;
@@ -133,6 +133,7 @@ import org.graylog.plugins.views.search.views.widgets.aggregation.sort.PivotSort
 import org.graylog.plugins.views.search.views.widgets.aggregation.sort.SeriesSortConfig;
 import org.graylog.plugins.views.search.views.widgets.events.EventsWidgetConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.messagelist.MessageListConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.text.TextWidgetConfigDTO;
 import org.graylog.plugins.views.startpage.StartPageResource;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityUpdatesListener;
 import org.graylog2.contentpacks.facades.DashboardEntityCreator;
@@ -323,6 +324,8 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(ValueConfigDTO.class);
 
         registerJacksonSubtype(EventsWidgetConfigDTO.class);
+
+        registerJacksonSubtype(TextWidgetConfigDTO.class);
     }
 
     private void registerVisualizationConfigSubtypes() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/favorites/FavoritesService.java
@@ -18,9 +18,9 @@ package org.graylog.plugins.views.favorites;
 
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
 import jakarta.inject.Inject;
@@ -29,6 +29,7 @@ import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
 import org.graylog.plugins.views.startpage.title.StartPageItemTitleRetriever;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.utils.MongoUtils;
@@ -121,9 +122,10 @@ public class FavoritesService {
     }
 
     Optional<FavoritesForUserDTO> findForUser(final String userId) {
-        return MongoUtils.stream(db.find(Filters.eq(FavoritesForUserDTO.FIELD_USER_ID, userId))).findAny();
+        return Optional.ofNullable(db.find(Filters.eq(FavoritesForUserDTO.FIELD_USER_ID, userId)).first());
     }
 
+    @MustBeClosed
     public Stream<FavoritesForUserDTO> streamAll() {
         return MongoUtils.stream(db.find());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/DashboardsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/DashboardsService.java
@@ -16,8 +16,9 @@
  */
 package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport;
 
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import jakarta.inject.Inject;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 
@@ -32,6 +33,7 @@ class DashboardsService {
         this.db = mongoCollections.collection(COLLECTION_NAME, Dashboard.class);
     }
 
+    @MustBeClosed
     Stream<Dashboard> streamAll() {
         return MongoUtils.stream(db.find());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/SavedSearchService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/SavedSearchService.java
@@ -16,8 +16,9 @@
  */
 package org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.savedsearch;
 
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import jakarta.inject.Inject;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 
@@ -36,6 +37,7 @@ public class SavedSearchService {
         this.db = mongoCollections.collection(COLLECTION_NAME, SavedSearch.class);
     }
 
+    @MustBeClosed
     public Stream<SavedSearch> streamAll() {
         return MongoUtils.stream(db.find());
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search;
 
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.permissions.SearchPermissions;
@@ -23,8 +24,6 @@ import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewResolver;
 import org.graylog.plugins.views.search.views.ViewService;
-
-import jakarta.inject.Inject;
 
 import java.util.HashSet;
 import java.util.List;
@@ -66,9 +65,11 @@ public class SearchDomain {
     }
 
     public List<Search> getAllForUser(SearchPermissions searchPermissions, Predicate<ViewDTO> viewReadPermission) {
-        return dbService.streamAll()
-                .filter(s -> hasReadPermissionFor(searchPermissions, viewReadPermission, s))
-                .collect(Collectors.toList());
+        try (final var stream = dbService.streamAll()) {
+            return stream
+                    .filter(s -> hasReadPermissionFor(searchPermissions, viewReadPermission, s))
+                    .collect(Collectors.toList());
+        }
     }
 
     public Search saveForUser(Search search, SearchUser searchUser) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/QualifyingViewsService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/QualifyingViewsService.java
@@ -17,11 +17,9 @@
 package org.graylog.plugins.views.search.views;
 
 import com.google.common.base.Functions;
+import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.db.SearchDbService;
-import org.graylog.plugins.views.search.Search;
-
-import jakarta.inject.Inject;
 
 import java.util.Collection;
 import java.util.Map;
@@ -39,17 +37,22 @@ public class QualifyingViewsService {
     }
 
     public Collection<ViewParameterSummaryDTO> forValue() {
-        final Set<String> searches = viewService.streamAll()
-                .map(ViewDTO::searchId)
-                .collect(Collectors.toSet());
+        final Set<String> searches;
+        try (final var stream = viewService.streamAll()) {
+            searches = stream
+                    .map(ViewDTO::searchId)
+                    .collect(Collectors.toSet());
+        }
         final Map<String, Search> qualifyingSearches = this.searchDbService.findByIds(searches).stream()
                 .filter(search -> !search.parameters().isEmpty())
                 .collect(Collectors.toMap(Search::id, Functions.identity()));
 
-        return viewService.streamAll()
-                .filter(view -> qualifyingSearches.keySet().contains(view.searchId()))
-                .map(view -> ViewParameterSummaryDTO.create(view, qualifyingSearches.get(view.searchId())))
-                .collect(Collectors.toSet());
+        try (final var stream = viewService.streamAll()) {
+            return stream
+                    .filter(view -> qualifyingSearches.containsKey(view.searchId()))
+                    .map(view -> ViewParameterSummaryDTO.create(view, qualifyingSearches.get(view.searchId())))
+                    .collect(Collectors.toSet());
+        }
     }
 
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.views;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.MongoException;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Sorts;
@@ -194,19 +195,23 @@ public class ViewService implements ViewUtils<ViewDTO> {
     }
 
     public Collection<ViewDTO> forSearch(String searchId) {
-        return MongoUtils.stream(this.collection.find(Filters.eq(ViewDTO.FIELD_SEARCH_ID, searchId)))
-                .map(this::requirementsForView)
-                .collect(Collectors.toSet());
+        try (final var stream = MongoUtils.stream(this.collection.find(Filters.eq(ViewDTO.FIELD_SEARCH_ID, searchId)))) {
+            return stream
+                    .map(this::requirementsForView)
+                    .collect(Collectors.toSet());
+        }
     }
 
     public Optional<ViewDTO> get(String id) {
         return mongoUtils.getById(id).map(this::requirementsForView);
     }
 
+    @MustBeClosed
     public Stream<ViewDTO> streamAll() {
         return MongoUtils.stream(collection.find()).map(this::requirementsForView);
     }
 
+    @MustBeClosed
     public Stream<ViewDTO> streamByIds(Set<String> idSet) {
         return MongoUtils.stream(collection.find(MongoUtils.stringIdsIn(idSet))).map(this::requirementsForView);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/text/TextWidgetConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/text/TextWidgetConfigDTO.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+package org.graylog.plugins.views.search.views.widgets.text;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.views.WidgetConfigDTO;
+
+@AutoValue
+@JsonTypeName(TextWidgetConfigDTO.NAME)
+@JsonDeserialize(builder = TextWidgetConfigDTO.Builder.class)
+public abstract class TextWidgetConfigDTO implements WidgetConfigDTO {
+    public static final String NAME = "text";
+    private static final String FIELD_TEXT = "text";
+
+    @JsonProperty(FIELD_TEXT)
+    public abstract String text();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty(FIELD_TEXT)
+        public abstract Builder text(String text);
+
+        public abstract TextWidgetConfigDTO build();
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_TextWidgetConfigDTO.Builder();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/startpage/lastOpened/LastOpenedService.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.mongodb.MongoException;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Updates;
@@ -28,6 +27,7 @@ import jakarta.inject.Inject;
 import org.graylog.plugins.views.search.permissions.SearchUser;
 import org.graylog.plugins.views.startpage.recentActivities.ActivityType;
 import org.graylog.plugins.views.startpage.recentActivities.RecentActivityEvent;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 import org.graylog2.users.events.UserDeletedEvent;
@@ -53,7 +53,7 @@ public class LastOpenedService {
     }
 
     Optional<LastOpenedForUserDTO> findForUser(final String userId) {
-        return MongoUtils.stream(this.db.find(Filters.eq(LastOpenedForUserDTO.FIELD_USER_ID, userId))).findAny();
+        return Optional.ofNullable(this.db.find(Filters.eq(LastOpenedForUserDTO.FIELD_USER_ID, userId)).first());
     }
 
     public void create(final LastOpenedForUserDTO lastOpenedItems) {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobDefinitionService.java
@@ -18,12 +18,13 @@ package org.graylog.scheduler;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.model.Filters;
 import jakarta.inject.Inject;
 import one.util.streamex.StreamEx;
 import org.bson.conversions.Bson;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.utils.MongoUtils;
 
@@ -68,6 +69,7 @@ public class DBJobDefinitionService {
      * @param value       the value of the config field
      * @return a stream of job definitions with the given config field.
      */
+    @MustBeClosed
     public Stream<JobDefinitionDto> streamByConfigField(String configField, Object value) {
         return MongoUtils.stream(collection.find(buildConfigFieldQuery(configField, value)));
     }
@@ -112,8 +114,9 @@ public class DBJobDefinitionService {
         return mongoUtils.getById(id);
     }
 
+    @MustBeClosed
     public Stream<JobDefinitionDto> streamAll() {
-        return mongoUtils.stream(collection.find());
+        return MongoUtils.stream(collection.find());
     }
 
     public JobDefinitionDto findOrCreate(JobDefinitionDto dto) {

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DBJobTriggerService.java
@@ -21,7 +21,6 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.primitives.Ints;
 import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.AggregateIterable;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Accumulators;
 import com.mongodb.client.model.Aggregates;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -37,6 +36,7 @@ import org.graylog.scheduler.capabilities.SchedulerCapabilitiesService;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog.scheduler.schedule.OnceJobSchedule;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.utils.MongoUtils;
@@ -214,8 +214,11 @@ public class DBJobTriggerService {
                 .collect(Collectors.toSet());
 
         final var filter = in(FIELD_JOB_DEFINITION_ID, queryValues);
-        final Map<String, List<JobTriggerDto>> groupedTriggers = StreamEx.of(stream(collection.find(filter)))
-                .groupingBy(JobTriggerDto::jobDefinitionId);
+        final Map<String, List<JobTriggerDto>> groupedTriggers;
+        try (final var stream = stream(collection.find(filter));
+             final var streamEx = StreamEx.of(stream)) {
+            groupedTriggers = streamEx.groupingBy(JobTriggerDto::jobDefinitionId);
+        }
 
         // We are currently expecting only one trigger per job definition. This will most probably change in the
         // future once we extend our scheduler usage.
@@ -580,6 +583,8 @@ public class DBJobTriggerService {
                 )
         ), OverdueTrigger.class);
 
-        return stream(result).collect(Collectors.toMap(OverdueTrigger::type, OverdueTrigger::count));
+        try (final var stream = stream(result)) {
+            return stream.collect(Collectors.toMap(OverdueTrigger::type, OverdueTrigger::count));
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/authservice/DBAuthServiceBackendService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authservice/DBAuthServiceBackendService.java
@@ -20,12 +20,12 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.errorprone.annotations.MustBeClosed;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Filters;
 import jakarta.inject.Inject;
 import org.bson.conversions.Bson;
 import org.graylog.security.events.AuthServiceBackendDeletedEvent;
 import org.graylog.security.events.AuthServiceBackendSavedEvent;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.pagination.MongoPaginationHelper;
@@ -139,6 +139,7 @@ public class DBAuthServiceBackendService {
         return MongoUtils.stream(collection.find());
     }
 
+    @MustBeClosed
     public Stream<AuthServiceBackendDTO> streamByIds(Set<String> idSet) {
         return MongoUtils.stream(collection.find(stringIdsIn(idSet)));
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/indices/MongoDbIndexTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/indices/MongoDbIndexTools.java
@@ -114,11 +114,13 @@ public class MongoDbIndexTools {
         if (existingIndices == null) {
             return Optional.empty();
         }
-        return MongoUtils.stream(existingIndices)
-                .filter(info ->
-                        info.get(INDEX_DOCUMENT_KEY, Document.class).containsKey(sortField)
-                )
-                .findFirst();
+        try (final var stream = MongoUtils.stream(existingIndices)) {
+            return stream
+                    .filter(info ->
+                            info.get(INDEX_DOCUMENT_KEY, Document.class).containsKey(sortField)
+                    )
+                    .findFirst();
+        }
     }
 
     public void createUniqueIndex(final String field) {

--- a/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/suggestions/MongoEntitySuggestionService.java
@@ -18,6 +18,7 @@ package org.graylog2.database.suggestions;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Streams;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
@@ -82,25 +83,33 @@ public class MongoEntitySuggestionService implements EntitySuggestionService {
         final var userCanReadAllEntities = permissionsUtils.hasAllPermission(subject) || permissionsUtils.hasReadPermissionForWholeCollection(subject, collection);
         final var skip = Math.max(0, (page - 1) * perPage - fixNumberOfItemsToReadFromDB);
         final var checkPermission = permissionsUtils.createPermissionCheck(subject, collection);
-        final var documents = userCanReadAllEntities
+
+        final List<EntitySuggestion> suggestions;
+        try (final var documents = userCanReadAllEntities
                 ? mongoPaginate(resultWithoutPagination, perPage - fixNumberOfItemsToReadFromDB, skip)
-                : paginateWithPermissionCheck(resultWithoutPagination, perPage - fixNumberOfItemsToReadFromDB, skip, checkPermission);
+                : paginateWithPermissionCheck(resultWithoutPagination, perPage - fixNumberOfItemsToReadFromDB, skip, checkPermission)) {
 
-        final List<EntitySuggestion> staticEntry = isFirstPageAndSpecialCollection ? List.of(new EntitySuggestion(LOCAL_ADMIN_ID, "admin")) : List.of();
+            final List<EntitySuggestion> staticEntry = isFirstPageAndSpecialCollection ? List.of(new EntitySuggestion(LOCAL_ADMIN_ID, "admin")) : List.of();
 
-        final Stream<EntitySuggestion> suggestionsFromDB = documents
-                .map(doc ->
-                        new EntitySuggestion(
-                                doc.getObjectId(ID_FIELD).toString(),
-                                doc.getString(valueColumn)
-                        )
-                );
+            final Stream<EntitySuggestion> suggestionsFromDB = documents
+                    .map(doc ->
+                            new EntitySuggestion(
+                                    doc.getObjectId(ID_FIELD).toString(),
+                                    doc.getString(valueColumn)
+                            )
+                    );
 
-        final List<EntitySuggestion> suggestions = Streams.concat(staticEntry.stream(), suggestionsFromDB).toList();
+            suggestions = Streams.concat(staticEntry.stream(), suggestionsFromDB).toList();
+        }
 
-        final long total = userCanReadAllEntities
-                ? mongoCollection.countDocuments(bsonFilter)
-                : MongoUtils.stream(mongoCollection.find(bsonFilter).projection(Projections.include(ID_FIELD))).filter(checkPermission).count();
+        final long total;
+        if (userCanReadAllEntities) {
+            total = mongoCollection.countDocuments(bsonFilter);
+        } else {
+            try (final var stream = MongoUtils.stream(mongoCollection.find(bsonFilter).projection(Projections.include(ID_FIELD)))) {
+                total = stream.filter(checkPermission).count();
+            }
+        }
 
         return new EntitySuggestionResponse(suggestions,
                 PaginatedList.PaginationInfo.create((int) total,
@@ -109,6 +118,7 @@ public class MongoEntitySuggestionService implements EntitySuggestionService {
                         perPage));
     }
 
+    @MustBeClosed
     private Stream<Document> paginateWithPermissionCheck(FindIterable<Document> result, int limit, int skip, Predicate<Document> checkPermission) {
         return MongoUtils.stream(result)
                 .filter(checkPermission)
@@ -116,6 +126,7 @@ public class MongoEntitySuggestionService implements EntitySuggestionService {
                 .skip(skip);
     }
 
+    @MustBeClosed
     private Stream<Document> mongoPaginate(FindIterable<Document> result, int limit, int skip) {
         return MongoUtils.stream(result.limit(limit).skip(skip));
     }

--- a/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/utils/MongoUtils.java
@@ -17,6 +17,7 @@
 package org.graylog2.database.utils;
 
 import com.google.common.collect.Streams;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.ErrorCategory;
 import com.mongodb.MongoException;
 import com.mongodb.client.MongoIterable;
@@ -147,6 +148,7 @@ public class MongoUtils<T extends MongoEntity> {
      * @param <T>           document type of the underlying collection
      * @return A stream that should be used in a try-with-resources statement or closed manually to free underlying resources.
      */
+    @MustBeClosed
     public static <T> Stream<T> stream(@Nonnull MongoIterable<T> mongoIterable) {
         final var cursor = mongoIterable.cursor();
         return Streams.stream(cursor).onClose(cursor::close);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/template/IndexSetTemplateService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/template/IndexSetTemplateService.java
@@ -17,12 +17,13 @@
 package org.graylog2.indexer.indexset.template;
 
 import com.google.common.primitives.Ints;
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Sorts;
 import jakarta.inject.Inject;
 import org.bson.conversions.Bson;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.filtering.DbQueryCreator;
@@ -137,6 +138,7 @@ public class IndexSetTemplateService {
                 DEFAULTS);
     }
 
+    @MustBeClosed
     public Stream<IndexSetTemplate> streamAll() {
         return stream(collection.find());
     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/db/DBLookupTableService.java
@@ -17,12 +17,12 @@
 package org.graylog2.lookup.db;
 
 import com.google.errorprone.annotations.MustBeClosed;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import jakarta.inject.Inject;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.entities.EntityScopeService;
@@ -134,6 +134,6 @@ public class DBLookupTableService {
     }
 
     public void forEach(Consumer<? super LookupTableDto> action) {
-        stream(collection.find()).forEach(action);
+        collection.find().forEach(action);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnerShipToGrantsMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnerShipToGrantsMigration.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
+import jakarta.inject.Named;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNType;
@@ -28,8 +29,6 @@ import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import jakarta.inject.Named;
 
 import java.util.Optional;
 
@@ -56,15 +55,17 @@ public class ViewOwnerShipToGrantsMigration {
     }
 
     public void upgrade() {
-        viewService.streamAll().forEach(view -> {
-            final Optional<User> user = view.owner().map(userService::load);
-            if (user.isPresent() && !user.get().isLocalAdmin()) {
-                final GRNType grnType = ViewDTO.Type.DASHBOARD.equals(view.type()) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH;
-                final GRN target = grnType.toGRN(view.id());
+        try (final var stream = viewService.streamAll()) {
+            stream.forEach(view -> {
+                final Optional<User> user = view.owner().map(userService::load);
+                if (user.isPresent() && !user.get().isLocalAdmin()) {
+                    final GRNType grnType = ViewDTO.Type.DASHBOARD.equals(view.type()) ? GRNTypes.DASHBOARD : GRNTypes.SEARCH;
+                    final GRN target = grnType.toGRN(view.id());
 
-                ensureGrant(user.get(), target);
-            }
-        });
+                    ensureGrant(user.get(), target);
+                }
+            });
+        }
     }
 
     private void ensureGrant(User user, GRN target) {

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20230523160600_PopulateEventDefinitionState.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20230523160600_PopulateEventDefinitionState.java
@@ -62,7 +62,7 @@ public class V20230523160600_PopulateEventDefinitionState extends Migration {
         // Collect a list of all event definitions with a defined job (ie, enabled event definitions) as well as all
         // system event definitions to be marked as enabled
         List<String> enabledEventDefinitionIds = new ArrayList<>();
-        try (var stream = dbEventDefinitionService.streamAll()) {
+        try (final var stream = dbEventDefinitionService.streamAll()) {
             stream.forEach(dto -> {
                 Optional<JobDefinitionDto> jobDefinition = dbJobDefinitionService.getByConfigField(EventDto.FIELD_EVENT_DEFINITION_ID, dto.id());
                 if (dto.scope().equals(NonDeletableSystemScope.NAME) || jobDefinition.isPresent()) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/bundle/SupportBundleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/debug/bundle/SupportBundleService.java
@@ -463,7 +463,7 @@ public class SupportBundleService {
                 if (response.entity().isPresent()) {
                     final String logName = Path.of(logFile.name()).getFileName().toString();
                     try (FileOutputStream fileOutputStream = new FileOutputStream(logDir.resolve(logName).toFile())) {
-                        try (var logFileStream = response.entity().get().byteStream()) {
+                        try (final var logFileStream = response.entity().get().byteStream()) {
                             logFileStream.transferTo(fileOutputStream);
                         }
                     }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/users/UsersResource.java
@@ -727,13 +727,9 @@ public class UsersResource extends RestResource {
             @ApiParam(name = "name", value = "Descriptive name for this token (e.g. 'cronjob') ", required = true) @PathParam("name") String name,
             @ApiParam(name = "JSON Body", value = "Can optionally contain the token's TTL.", defaultValue = "{\"token_ttl\":null}") GenerateTokenTTL body) {
         final User futureOwner = loadUserById(userId);
-        final User currentUser = getCurrentUser();
 
-        if (currentUser == null) {
-            throw new ForbiddenException("Not allowed to create tokens for unknown user.");
-        }
-        if (!isPermitted(USERS_TOKENCREATE, currentUser.getName())) {
-            throw new ForbiddenException(currentUser.getName() + " is not allowed to create token.");
+        if (!isPermitted(USERS_TOKENCREATE, futureOwner.getName())) {
+            throw new ForbiddenException("You are not allowed to create a token for user " + futureOwner.getName() + ".");
         }
 
         if (body == null) {

--- a/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AccessTokenServiceImpl.java
@@ -303,7 +303,7 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
 
         final MongoCollection<Document> tokenColl = mongoCollection(AccessTokenImpl.class);
         final AggregateIterable<Document> aggregateIt = tokenColl.aggregate(pipeline);
-        try (var stream = StreamSupport.stream(aggregateIt.spliterator(), false)) {
+        try (final var stream = StreamSupport.stream(aggregateIt.spliterator(), false)) {
             return stream.map(d -> {
                 final Optional<Document> userDetails = Optional.ofNullable(d.get(join, Document.class));
                         return new ExpiredToken(
@@ -335,7 +335,7 @@ public class AccessTokenServiceImpl extends PersistedServiceImpl implements Acce
                         include(AccessTokenImpl.USERNAME)
                 ))
         ));
-        try (var stream = StreamSupport.stream(aggregateIt.spliterator(), false)) {
+        try (final var stream = StreamSupport.stream(aggregateIt.spliterator(), false)) {
             return stream.map(d ->
                             new ExpiredToken(
                                     d.getObjectId(AccessTokenImpl.ID_FIELD).toString(),

--- a/graylog2-server/src/main/java/org/graylog2/tokenusage/TokenUsageServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/tokenusage/TokenUsageServiceImpl.java
@@ -85,8 +85,11 @@ public class TokenUsageServiceImpl implements TokenUsageService {
         LOG.debug("Found {} distinct authentication services used by users of current page of access tokens.", allAuthServiceIds.size());
 
         //Load corresponding auth-services and extract the title:
-        final Map<String, String> authServiceIdToTitle = dbAuthServiceBackendService.streamByIds(allAuthServiceIds)
-                .collect(Collectors.toMap(AuthServiceBackendDTO::id, AuthServiceBackendDTO::title));
+        final Map<String, String> authServiceIdToTitle;
+        try (final var stream = dbAuthServiceBackendService.streamByIds(allAuthServiceIds)) {
+            authServiceIdToTitle = stream
+                    .collect(Collectors.toMap(AuthServiceBackendDTO::id, AuthServiceBackendDTO::title));
+        }
 
         //Build up the resulting objects:
         final List<TokenUsageDTO> tokenUsage = currentPage.stream()

--- a/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
@@ -16,10 +16,11 @@
  */
 package org.graylog2.users;
 
-import org.graylog2.database.MongoCollection;
+import com.google.errorprone.annotations.MustBeClosed;
 import jakarta.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.bson.types.ObjectId;
+import org.graylog2.database.MongoCollection;
 import org.graylog2.database.MongoCollections;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.database.pagination.MongoPaginationHelper;
@@ -101,6 +102,7 @@ public class PaginatedUserService {
                 .page(page);
     }
 
+    @MustBeClosed
     public Stream<UserOverviewDTO> streamAll() {
         return MongoUtils.stream(collection.find());
     }

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/NotificationFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/NotificationFacadeTest.java
@@ -225,6 +225,7 @@ public class NotificationFacadeTest {
 
     @Test
     @MongoDBFixtures("NotificationFacadeTest.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void delete() {
         long countBefore = notificationService.streamAll().count();
         assertThat(countBefore).isEqualTo(1);

--- a/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
@@ -147,6 +147,7 @@ public class LegacyAlertConditionMigratorTest {
 
     @Test
     @MongoDBFixtures("legacy-alert-conditions.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void run() {
         final int migratedConditions = 10;
         final int migratedCallbacks = 4;
@@ -644,6 +645,7 @@ public class LegacyAlertConditionMigratorTest {
 
     @Test
     @MongoDBFixtures("legacy-alert-conditions.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void runWithMigrationStatus() {
         final int migratedConditions = 9; // Only 8 because we pass one migrated condition in
         final int migratedCallbacks = 3;  // Only 2 because we pass one migrated callback in

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionHandlerTest.java
@@ -448,6 +448,7 @@ public class EventDefinitionHandlerTest {
 
     @Test
     @MongoDBFixtures("event-processors-without-schedule.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void schedule() {
         assertThat(eventDefinitionService.get("54e3deadbeefdeadbeef0000")).isPresent();
         assertThat(jobDefinitionService.streamAll().count()).isEqualTo(0);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoritesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/favorites/FavoritesServiceTest.java
@@ -99,6 +99,7 @@ public class FavoritesServiceTest {
     }
 
     @Test
+    @SuppressWarnings("MustBeClosedChecker")
     public void testRemoveOnUserDeletion() {
         var _1 = grnRegistry.newGRN(GRNTypes.DASHBOARD, "1");
         var _2 = grnRegistry.newGRN(GRNTypes.SEARCH, "2");
@@ -115,6 +116,7 @@ public class FavoritesServiceTest {
     }
 
     @Test
+    @SuppressWarnings("MustBeClosedChecker")
     public void testRemoveOnEntityDeletion() {
         var _1 = grnRegistry.newGRN(GRNTypes.DASHBOARD, "1");
         var _2 = grnRegistry.newGRN(GRNTypes.SEARCH, "2");

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceUsesViewRequirementsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/ViewServiceUsesViewRequirementsTest.java
@@ -174,6 +174,7 @@ public class ViewServiceUsesViewRequirementsTest {
 
     @Test
     @MongoDBFixtures("views.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void streamAllReturnsViewWithViewRequirements() {
         final List<ViewDTO> views = viewService.streamAll().collect(Collectors.toList());
 
@@ -185,6 +186,7 @@ public class ViewServiceUsesViewRequirementsTest {
 
     @Test
     @MongoDBFixtures("views.json")
+    @SuppressWarnings("MustBeClosedChecker")
     public void streamByIdsReturnsViewWithViewRequirements() {
         final List<ViewDTO> views = viewService.streamByIds(
                 ImmutableSet.of("5ced4df1d6e8104c16f50e00", "5ced4a4485b52a86b96a0a63")

--- a/graylog2-server/src/test/java/org/graylog2/database/HelpersAndUtilitiesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/database/HelpersAndUtilitiesTest.java
@@ -17,7 +17,6 @@
 package org.graylog2.database;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.graylog2.database.MongoCollection;
 import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Sorts;
 import jakarta.annotation.Nullable;
@@ -196,6 +195,7 @@ class HelpersAndUtilitiesTest {
     }
 
     @Test
+    @SuppressWarnings("MustBeClosedChecker")
     public void streamAll() {
         collection.insertOne(newDto("hello1"));
         collection.insertOne(newDto("hello2"));

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/users/UsersResourceTest.java
@@ -93,7 +93,6 @@ public class UsersResourceTest {
     private static final String TOKEN_NAME = "tokenName";
 
     private static final String ADMIN_OBJECT_ID = new ObjectId().toHexString();
-    private static final PeriodDuration PD_30_DAYS = PeriodDuration.parse("P30D");
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -212,7 +211,6 @@ public class UsersResourceTest {
             final UsersResource.GenerateTokenTTL ttl = new UsersResource.GenerateTokenTTL(Optional.of(PeriodDuration.of(Duration.ofDays(30))));
             assertThrows(ForbiddenException.class, () -> usersResource.generateNewToken(USERNAME, TOKEN_NAME, ttl));
         } finally {
-            verify(subject).getPrincipal();
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
@@ -227,7 +225,6 @@ public class UsersResourceTest {
             final Token actual = usersResource.generateNewToken(USERNAME, TOKEN_NAME, null);
             assertEquals(expected, actual);
         } finally {
-            verify(subject).getPrincipal();
             verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verify(clusterConfigService).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
             verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
@@ -246,8 +243,7 @@ public class UsersResourceTest {
             final Token actual = usersResource.generateNewToken(USERNAME, TOKEN_NAME, null);
             assertEquals(expected, actual);
         } finally {
-            verify(subject).getPrincipal();
-            verify(subject).isPermitted(USERS_TOKENCREATE + ":" + adminUserName);
+            verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verify(clusterConfigService).getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES);
             verify(accessTokenService).create(USERNAME, TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)));
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
@@ -264,8 +260,7 @@ public class UsersResourceTest {
         try {
             assertThrows(ForbiddenException.class, () -> usersResource.generateNewToken(USERNAME, TOKEN_NAME, null));
         } finally {
-            verify(subject).getPrincipal();
-            verify(subject).isPermitted(USERS_TOKENCREATE + ":" + otherUserName);
+            verify(subject).isPermitted(USERS_TOKENCREATE + ":" + USERNAME);
             verifyNoMoreInteractions(clusterConfigService, accessTokenService);
         }
     }
@@ -290,14 +285,14 @@ public class UsersResourceTest {
             user.setRoleIds(Set.of(ADMIN_OBJECT_ID));
         }
 
-        when(subject.getPrincipal()).thenReturn(callingUserName);
-        when(userService.loadById(callingUserName)).thenReturn(user);
-        when(roleService.getAdminRoleObjectId()).thenReturn(ADMIN_OBJECT_ID);
+        final boolean allowedToCreateToken = callingUserName.equals(owningUserName) || isAdmin;
         when(userManagementService.loadById(USERNAME)).thenReturn(userImplFactory.create(owningUser));
-        when(subject.isPermitted(USERS_TOKENCREATE + ":" + callingUserName)).thenReturn(callingUserName.equals(owningUserName) || isAdmin);
-        when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
-                .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), false, false, PeriodDuration.of(Duration.ofDays(30))));
-        when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
+        when(subject.isPermitted(USERS_TOKENCREATE + ":" + owningUserName)).thenReturn(allowedToCreateToken);
+        if (allowedToCreateToken) {
+            when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES))
+                    .thenReturn(UserConfiguration.create(false, Duration.of(8, ChronoUnit.HOURS), false, false, PeriodDuration.of(Duration.ofDays(30))));
+            when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
+        }
 
         return Token.create(tokenId.toHexString(), TOKEN_NAME, token, lastAccess);
 
@@ -308,7 +303,7 @@ public class UsersResourceTest {
         final DateTime lastAccess = Tools.nowUTC();
         final Map<String, Object> tokenProps = Map.of(AccessTokenImpl.NAME, TOKEN_NAME, AccessTokenImpl.TOKEN, token, AccessTokenImpl.LAST_ACCESS, lastAccess);
         final ObjectId tokenId = new ObjectId();
-        final AccessToken accessToken = new AccessTokenImpl(tokenId, tokenProps);
+        final AccessToken accessToken = allowCreateToken ? new AccessTokenImpl(tokenId, tokenProps) : null;
 
         prepareMocks(userProps, accessToken, allowCreateToken);
 
@@ -317,11 +312,11 @@ public class UsersResourceTest {
 
     private void prepareMocks(Map<String, Object> userProps, AccessToken accessToken, boolean allow) {
         final User user = userImplFactory.create(userProps);
-        when(subject.getPrincipal()).thenReturn(USERNAME);
-        when(userService.loadById(USERNAME)).thenReturn(user);
         when(userManagementService.loadById(USERNAME)).thenReturn(user);
         when(subject.isPermitted(USERS_TOKENCREATE + ":" + USERNAME)).thenReturn(allow);
-        when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
+        if (allow) {
+            when(clusterConfigService.getOrDefault(UserConfiguration.class, UserConfiguration.DEFAULT_VALUES)).thenReturn(UserConfiguration.DEFAULT_VALUES);
+        }
         if (accessToken != null) {
             when(accessTokenService.create(USERNAME, UsersResourceTest.TOKEN_NAME, PeriodDuration.of(Duration.ofDays(30)))).thenReturn(accessToken);
         }

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@babel/eslint-parser": "7.16.5",
     "@tanstack/eslint-plugin-query": "5.74.7",
-    "@typescript-eslint/eslint-plugin": "8.34.1",
-    "@typescript-eslint/parser": "8.34.1",
+    "@typescript-eslint/eslint-plugin": "8.35.0",
+    "@typescript-eslint/parser": "8.35.0",
     "eslint": "8.57.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "10.1.5",

--- a/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/DateRangeForm.tsx
+++ b/graylog2-web-interface/src/components/common/EntityFilters/FilterConfiguration/DateRangeForm.tsx
@@ -107,10 +107,6 @@ const validate = (values: FormValues) => {
     errors = { ...errors, until: rangeError };
   }
 
-  if (values.from === undefined && values.until === undefined) {
-    errors = { ...errors, from: 'Remove filter to search from "All time" until "Now".' };
-  }
-
   return errors;
 };
 

--- a/graylog2-web-interface/src/components/common/Markdown.tsx
+++ b/graylog2-web-interface/src/components/common/Markdown.tsx
@@ -23,6 +23,13 @@ type Props = {
   text: string;
 };
 
+DOMPurify.addHook('afterSanitizeAttributes', (node) => {
+  if (node instanceof HTMLAnchorElement && node.getAttribute('href')) {
+    node.setAttribute('target', '_blank');
+    node.setAttribute('rel', 'noopener noreferrer');
+  }
+});
+
 const Markdown = ({ text }: Props) => {
   // Remove dangerous HTML
   const sanitizedText = DOMPurify.sanitize(text ?? '', { USE_PROFILES: { html: false } });

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/BaseEditor.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/BaseEditor.tsx
@@ -32,6 +32,7 @@ const EditorStyles = styled.div<{ $width: string }>`
 `;
 
 type Props = {
+  autoFocus?: boolean;
   value: string;
   onChange: (mdValue: string) => void;
   width?: string;
@@ -42,6 +43,7 @@ type Props = {
 };
 
 function MDBaseEditor({
+  autoFocus = false,
   value,
   onChange,
   id = 'md-editor',
@@ -64,6 +66,7 @@ function MDBaseEditor({
   return (
     <EditorStyles $width={width}>
       <SourceCodeEditor
+        focus={autoFocus}
         id={id}
         mode="markdown"
         theme="light"

--- a/graylog2-web-interface/src/components/common/MarkdownEditor/Preview.tsx
+++ b/graylog2-web-interface/src/components/common/MarkdownEditor/Preview.tsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 
+import NumberUtils from 'util/NumberUtils';
 import { Markdown, IconButton } from 'components/common';
 
 import PreviewModal from './PreviewModal';
@@ -37,7 +38,7 @@ const Container = styled.div<{ $height?: number | string; $noBackground?: boolea
 
   height: ${({ $height }) =>
     // eslint-disable-next-line no-nested-ternary
-    $height ? (Number.isInteger($height) ? `${$height}px` : $height) : 'auto'};
+    $height ? (NumberUtils.isNumber($height) ? `${$height}px` : $height) : 'auto'};
   min-height: 100px;
   width: 100%;
 `;

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -140,7 +140,7 @@ type Props = {
   children: React.ReactNode;
 };
 
-const svgDataUrl = (content: string) => `data:image/svg+xml;utf-8,${encodeURIComponent(content)}`;
+const svgDataUrl = (content: string) => `data:image/svg+xml;base64,${window.btoa(content)}`;
 const useLoginBackground = () =>
   useMemo(
     () =>

--- a/graylog2-web-interface/src/components/login/LoginChrome.tsx
+++ b/graylog2-web-interface/src/components/login/LoginChrome.tsx
@@ -136,16 +136,19 @@ const CustomizableLogo = () => {
   );
 };
 
+const sanitize = (content: string) =>
+  DOMPurify.sanitize(content, { USE_PROFILES: { svg: true }, ADD_TAGS: ['use'], ADD_ATTR: ['xlink:href'] });
+
 type Props = {
   children: React.ReactNode;
 };
 
-const svgDataUrl = (content: string) => `data:image/svg+xml;base64,${window.btoa(content)}`;
+const svgDataUrl = (content: string) => `data:image/svg+xml;base64,${Buffer.from(content).toString('base64')}`;
 const useLoginBackground = () =>
   useMemo(
     () =>
       AppConfig.branding()?.login?.background
-        ? svgDataUrl(DOMPurify.sanitize(AppConfig.branding()?.login?.background))
+        ? svgDataUrl(sanitize(AppConfig.branding()?.login?.background))
         : backgroundImage,
     [],
   );

--- a/graylog2-web-interface/src/views/bindings.tsx
+++ b/graylog2-web-interface/src/views/bindings.tsx
@@ -15,7 +15,6 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import get from 'lodash/get';
 import type { PluginExports } from 'graylog-web-plugin/plugin';
 
 import type { WidgetComponentProps } from 'views/types';
@@ -118,6 +117,10 @@ import WarmTierQueryValidation from 'views/components/searchbar/queryvalidation/
 import ExportMessageWidgetAction from 'views/components/widgets/ExportWidgetAction/ExportMessageWidgetAction';
 import ExportWidgetAction from 'views/components/widgets/ExportWidgetAction/ExportWidgetAction';
 import FieldTypeValueRenderer from 'views/components/fieldtypes/FieldTypeValueRenderer';
+import AddTextWidget, { CreateTextWidget } from 'views/logic/creatoractions/AddTextWidget';
+import TextWidget from 'views/logic/widgets/TextWidget';
+import TextVisualization from 'views/components/widgets/text/TextVisualization';
+import TextWidgetEdit from 'views/components/widgets/text/TextWidgetEdit';
 
 import type { ActionHandlerArguments } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
@@ -206,7 +209,7 @@ const exports: PluginExports = {
       editComponent: AggregationWizard,
       hasEditSubmitButton: true,
       needsControlledHeight: (widget: Widget) => {
-        const widgetVisualization = get(widget, 'config.visualization');
+        const widgetVisualization = widget?.config?.visualization;
         const flexibleHeightWidgets = [DataTable.type];
 
         return !flexibleHeightWidgets.find((visualization) => visualization === widgetVisualization);
@@ -237,6 +240,19 @@ const exports: PluginExports = {
       titleGenerator: () => EventsWidget.defaultTitle,
       needsControlledHeight: () => false,
       searchResultTransformer: (data: Array<unknown>) => data?.[0],
+    },
+    {
+      type: 'TEXT',
+      displayName: 'Text (Markdown) Widget',
+      defaultHeight: 3,
+      defaultWidth: 3,
+      hasEditSubmitButton: false,
+      visualizationComponent: TextVisualization,
+      editComponent: TextWidgetEdit,
+      searchTypes: () => [],
+      titleGenerator: () => TextWidget.defaultTitle,
+      needsControlledHeight: () => false,
+      searchResultTransformer: () => ({}),
     },
     {
       type: 'default',
@@ -416,6 +432,11 @@ const exports: PluginExports = {
       func: CreateEventsWidget,
       icon: () => <Icon name="report" type="regular" />,
     },
+    {
+      title: 'Text (Markdown) Widget',
+      func: CreateTextWidget,
+      icon: () => <Icon name="description" />,
+    },
   ],
   creators: [
     {
@@ -437,6 +458,11 @@ const exports: PluginExports = {
       type: 'events' as const,
       title: 'Events Overview',
       func: AddEventsWidgetActionHandler,
+    },
+    {
+      type: 'generic',
+      title: 'Text (Markdown) Widget',
+      func: AddTextWidget,
     },
   ],
   'views.completers': [new FieldNameCompletion(), new FieldValueCompletion(), new OperatorCompletion()],

--- a/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.tsx
+++ b/graylog2-web-interface/src/views/components/contexts/SearchExplainContextProvider.tsx
@@ -57,7 +57,7 @@ const SearchExplainContextProvider = ({ children }: { children: React.ReactNode 
       widgetId: string,
       widgetMapping: WidgetMapping,
     ): WidgetExplain | undefined => {
-      const searchTypeId = widgetMapping?.get(widgetId).first();
+      const searchTypeId = widgetMapping?.get(widgetId)?.first();
 
       return searchExplain?.search?.queries?.[queryId]?.search_types?.[searchTypeId];
     };

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/Constants.ts
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/Constants.ts
@@ -21,6 +21,6 @@ export const ENTITY_TABLE_ID = 'saved-searches';
 export const DEFAULT_LAYOUT = {
   pageSize: 20,
   sort: { attributeId: 'title', direction: 'asc' } as Sort,
-  displayedColumns: ['title', 'description', 'summary', 'favorite'],
+  displayedColumns: ['title', 'summary', 'favorite'],
   columnsOrder: ['title', 'summary', 'description', 'owner', 'created_at', 'last_updated_at', 'favorite'],
 };

--- a/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/UnknownWidget.tsx
@@ -50,10 +50,8 @@ const OrderedList = styled.ol`
   list-style: decimal inside none;
 `;
 
-const UnknownWidget: React.ComponentType<WidgetComponentProps & EditWidgetComponentProps> = ({
-  config,
-  type,
-}: WidgetComponentProps & EditWidgetComponentProps) => {
+type Props = WidgetComponentProps & EditWidgetComponentProps;
+const UnknownWidget = ({ config, type }: Props) => {
   const productName = useProductName();
 
   return (

--- a/graylog2-web-interface/src/views/components/widgets/text/TextVisualization.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/text/TextVisualization.test.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, screen } from 'wrappedTestingLibrary';
+
+import TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+
+import OriginalTextVisualization from './TextVisualization';
+
+const TextVisualization = ({ text }: { text: string }) => (
+  <OriginalTextVisualization
+    config={new TextWidgetConfig(text)}
+    height={100}
+    width={100}
+    data={{}}
+    editing={false}
+    fields={Immutable.List()}
+    queryId=""
+    setLoadingState={() => {}}
+    id=""
+  />
+);
+
+describe('TextVisualization', () => {
+  it('renders basic markdown', async () => {
+    render(<TextVisualization text="# Hey there!" />);
+
+    await screen.findByRole('heading', { name: 'Hey there!' });
+  });
+
+  it('renders link to open in new window', async () => {
+    render(<TextVisualization text="[A link](https://www.graylog.org/)" />);
+
+    const link = await screen.findByRole('link', { name: 'A link' });
+
+    expect(link).toHaveAttribute('href', 'https://www.graylog.org/');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/text/TextVisualization.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/text/TextVisualization.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+
+import type TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+import Preview from 'components/common/MarkdownEditor/Preview';
+import type { WidgetComponentProps } from 'views/types';
+
+const TextVisualization = ({ config, height }: WidgetComponentProps<TextWidgetConfig>) => (
+  <Preview value={config?.text} height={height} noBorder show />
+);
+export default TextVisualization;

--- a/graylog2-web-interface/src/views/components/widgets/text/TextWidgetEdit.test.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/text/TextWidgetEdit.test.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, screen } from 'wrappedTestingLibrary';
+import userEvent from '@testing-library/user-event';
+
+import TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+import TextWidget from 'views/logic/widgets/TextWidget';
+
+import OriginalTextWidgetEdit from './TextWidgetEdit';
+
+const TextWidgetEdit = ({ text }: { text: string }) => (
+  <OriginalTextWidgetEdit
+    config={new TextWidgetConfig(text)}
+    editing
+    id=""
+    type={TextWidget.type}
+    fields={Immutable.List()}
+    onChange={jest.fn()}
+    onCancel={jest.fn()}>
+    Test!
+  </OriginalTextWidgetEdit>
+);
+
+describe('TextWidgetEdit', () => {
+  it('renders existing text', async () => {
+    render(<TextWidgetEdit text="# Hey there!" />);
+
+    await screen.findByRole('heading', { name: 'Hey there!' });
+  });
+
+  it('reflects changes in the editor immediately', async () => {
+    render(<TextWidgetEdit text="" />);
+
+    const editor = await screen.findByRole('textbox');
+
+    await userEvent.type(editor, 'Hey there');
+
+    await screen.findByText('Hey there');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/text/TextWidgetEdit.tsx
+++ b/graylog2-web-interface/src/views/components/widgets/text/TextWidgetEdit.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import * as React from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import styled from 'styled-components';
+import debounce from 'lodash/debounce';
+
+import TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+import MDBaseEditor from 'components/common/MarkdownEditor/BaseEditor';
+import Preview from 'components/common/MarkdownEditor/Preview';
+import type { EditWidgetComponentProps } from 'views/types';
+import FullSizeContainer from 'views/components/aggregationbuilder/FullSizeContainer';
+
+const EditorContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 5px;
+`;
+const Item = styled.div`
+  flex: 1;
+  height: 100%;
+`;
+const TextWidgetEdit = ({ config, onChange }: EditWidgetComponentProps<TextWidgetConfig>) => {
+  const [text, setText] = useState(config?.text ?? '');
+  const _onChange = useMemo(
+    () => debounce((newText: string) => onChange(new TextWidgetConfig(newText)), 200),
+    [onChange],
+  );
+
+  useEffect(() => {
+    _onChange(text);
+  }, [_onChange, text]);
+
+  return (
+    <FullSizeContainer>
+      {({ height }) => (
+        <EditorContainer>
+          <Item>
+            <MDBaseEditor
+              key={`markdown-editor-${height}`}
+              autoFocus
+              onChange={setText}
+              value={text}
+              height={height - 8}
+            />
+          </Item>
+          <Item>
+            <Preview value={text} height={height - 8} show />
+          </Item>
+        </EditorContainer>
+      )}
+    </FullSizeContainer>
+  );
+};
+export default TextWidgetEdit;

--- a/graylog2-web-interface/src/views/logic/creatoractions/AddTextWidget.ts
+++ b/graylog2-web-interface/src/views/logic/creatoractions/AddTextWidget.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import TextWidget from 'views/logic/widgets/TextWidget';
+import TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+import type { ViewsDispatch } from 'views/stores/useViewsDispatch';
+import { addWidget } from 'views/logic/slices/widgetActions';
+
+const defaultText = `
+## This is a new text widget!
+
+Please edit me to set the text you want to display. You can include:
+   - tables
+   - images
+   - links
+   - lists 
+   
+and more.
+`;
+
+export const CreateTextWidget = () => TextWidget.builder().newId().config(new TextWidgetConfig(defaultText)).build();
+export default () => (dispatch: ViewsDispatch) => dispatch(addWidget(CreateTextWidget()));

--- a/graylog2-web-interface/src/views/logic/widgets/TextWidget.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/TextWidget.ts
@@ -16,21 +16,20 @@
  */
 import { Map } from 'immutable';
 
-import isDeepEqual from 'stores/isDeepEqual';
-import isEqualForSearch from 'views/stores/isEqualForSearch';
-import type { FiltersType } from 'views/types';
+import Widget, { type WidgetState } from 'views/logic/widgets/Widget';
+import TextWidgetConfig from 'views/logic/widgets/TextWidgetConfig';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type { QueryString } from 'views/logic/queries/types';
+import type { FiltersType } from 'views/types';
 
-import Widget, { widgetAttributesForComparison } from './Widget';
-import MessagesWidgetConfig from './MessagesWidgetConfig';
-import type { WidgetState } from './Widget';
+export default class TextWidget extends Widget {
+  static type = 'text';
 
-import type { TimeRange } from '../queries/Query';
+  static defaultTitle = 'Untitled Text Widget';
 
-export default class MessagesWidget extends Widget {
   constructor(
     id: string,
-    config: MessagesWidgetConfig,
+    config: TextWidgetConfig,
     filter: string | undefined | null,
     timerange: TimeRange | undefined | null,
     query: QueryString | undefined | null,
@@ -38,24 +37,15 @@ export default class MessagesWidget extends Widget {
     streamCategories: Array<string>,
     filters?: FiltersType,
   ) {
-    super(id, MessagesWidget.type, config, filter, timerange, query, streams, streamCategories, filters);
-  }
-
-  static type = 'messages';
-
-  static defaultTitle = 'Untitled Message Table';
-
-  // eslint-disable-next-line class-methods-use-this
-  get isExportable() {
-    return true;
+    super(id, TextWidget.type, config, filter, timerange, query, streams, streamCategories, filters);
   }
 
   static fromJSON(value: WidgetState) {
     const { id, config, filter, timerange, query, streams, stream_categories, filters } = value;
 
-    return new MessagesWidget(
+    return new TextWidget(
       id,
-      MessagesWidgetConfig.fromJSON(config),
+      TextWidgetConfig.fromJSON(config),
       filter,
       timerange,
       query,
@@ -66,23 +56,15 @@ export default class MessagesWidget extends Widget {
   }
 
   equals(other: any) {
-    if (other instanceof MessagesWidget) {
-      return widgetAttributesForComparison.every((key) => isDeepEqual(this[key], other[key]));
+    if (other instanceof TextWidget) {
+      return this._value.id === other.id && this._value.config.equals(other.config);
     }
 
     return false;
-  }
-
-  get config(): MessagesWidgetConfig {
-    return this._value.config;
   }
 
   equalsForSearch(other: any) {
-    if (other instanceof MessagesWidget) {
-      return widgetAttributesForComparison.every((key) => isEqualForSearch(this[key], other[key]));
-    }
-
-    return false;
+    return other instanceof TextWidget && this._value.config.equalsForSearch(other.config);
   }
 
   toBuilder() {
@@ -96,16 +78,12 @@ export default class MessagesWidget extends Widget {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     return new Builder();
   }
-
-  static isMessagesWidget(widget: Widget) {
-    return widget && widget.type === MessagesWidget.type;
-  }
 }
 
 class Builder extends Widget.Builder {
   build() {
     const { id, config, filter, timerange, query, streams, stream_categories, filters } = this.value.toObject();
 
-    return new MessagesWidget(id, config, filter, timerange, query, streams, stream_categories, filters);
+    return new TextWidget(id, config, filter, timerange, query, streams, stream_categories, filters);
   }
 }

--- a/graylog2-web-interface/src/views/logic/widgets/TextWidgetConfig.ts
+++ b/graylog2-web-interface/src/views/logic/widgets/TextWidgetConfig.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
+import WidgetConfig from 'views/logic/widgets/WidgetConfig';
+
+export type TextWidgetConfigJSON = {
+  text: string;
+};
+export default class TextWidgetConfig extends WidgetConfig {
+  private readonly _text: string;
+
+  constructor(text: string) {
+    super();
+    this._text = text;
+  }
+
+  get text() {
+    return this._text;
+  }
+
+  toJSON() {
+    return {
+      text: this._text,
+    };
+  }
+
+  static empty() {
+    return new TextWidgetConfig('');
+  }
+
+  static fromJSON(value: TextWidgetConfigJSON) {
+    return new TextWidgetConfig(value.text);
+  }
+
+  equals(other: any): boolean {
+    return other instanceof TextWidgetConfig && this._text === other.text;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  equalsForSearch(_other: any): boolean {
+    // Should never trigger a new search
+    return true;
+  }
+}

--- a/graylog2-web-interface/src/views/types.ts
+++ b/graylog2-web-interface/src/views/types.ts
@@ -111,13 +111,13 @@ export interface WidgetComponentProps<Config extends WidgetConfig = WidgetConfig
   width: number;
 }
 
-export interface WidgetExport {
+export interface WidgetExport<T extends WidgetConfig = WidgetConfig> {
   type: string;
   displayName?: string;
   defaultHeight?: number;
   defaultWidth?: number;
-  visualizationComponent: React.ComponentType<WidgetComponentProps<any, any>>;
-  editComponent: React.ComponentType<EditWidgetComponentProps<any>>;
+  visualizationComponent: React.ComponentType<WidgetComponentProps<T, any>>;
+  editComponent: React.ComponentType<EditWidgetComponentProps<T>>;
   hasEditSubmitButton?: boolean;
   needsControlledHeight: (widget: { config: Widget['config'] }) => boolean;
   searchResultTransformer?: (data: Array<unknown>) => unknown;

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -3665,30 +3665,30 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/eslint-plugin@8.34.1":
-  version "8.34.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz#56cf35b89383eaf2bdcf602f5bbdac6dbb11e51b"
-  integrity sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==
+"@typescript-eslint/eslint-plugin@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz#515170100ff867445fe0a17ce05c14fc5fd9ca63"
+  integrity sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==
   dependencies:
     "@eslint-community/regexpp" "^4.10.0"
-    "@typescript-eslint/scope-manager" "8.34.1"
-    "@typescript-eslint/type-utils" "8.34.1"
-    "@typescript-eslint/utils" "8.34.1"
-    "@typescript-eslint/visitor-keys" "8.34.1"
+    "@typescript-eslint/scope-manager" "8.35.0"
+    "@typescript-eslint/type-utils" "8.35.0"
+    "@typescript-eslint/utils" "8.35.0"
+    "@typescript-eslint/visitor-keys" "8.35.0"
     graphemer "^1.4.0"
     ignore "^7.0.0"
     natural-compare "^1.4.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/parser@8.34.1":
-  version "8.34.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.34.1.tgz#f102357ab3a02d5b8aa789655905662cc5093067"
-  integrity sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==
+"@typescript-eslint/parser@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.35.0.tgz#20a0e17778a329a6072722f5ac418d4376b767d2"
+  integrity sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.34.1"
-    "@typescript-eslint/types" "8.34.1"
-    "@typescript-eslint/typescript-estree" "8.34.1"
-    "@typescript-eslint/visitor-keys" "8.34.1"
+    "@typescript-eslint/scope-manager" "8.35.0"
+    "@typescript-eslint/types" "8.35.0"
+    "@typescript-eslint/typescript-estree" "8.35.0"
+    "@typescript-eslint/visitor-keys" "8.35.0"
     debug "^4.3.4"
 
 "@typescript-eslint/project-service@8.33.1":
@@ -3707,6 +3707,15 @@
   dependencies:
     "@typescript-eslint/tsconfig-utils" "^8.34.1"
     "@typescript-eslint/types" "^8.34.1"
+    debug "^4.3.4"
+
+"@typescript-eslint/project-service@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.35.0.tgz#00bd77e6845fbdb5684c6ab2d8a400a58dcfb07b"
+  integrity sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==
+  dependencies:
+    "@typescript-eslint/tsconfig-utils" "^8.35.0"
+    "@typescript-eslint/types" "^8.35.0"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@8.16.0", "@typescript-eslint/scope-manager@^8.15.0":
@@ -3733,6 +3742,14 @@
     "@typescript-eslint/types" "8.34.1"
     "@typescript-eslint/visitor-keys" "8.34.1"
 
+"@typescript-eslint/scope-manager@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz#8ccb2ab63383544fab98fc4b542d8d141259ff4f"
+  integrity sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==
+  dependencies:
+    "@typescript-eslint/types" "8.35.0"
+    "@typescript-eslint/visitor-keys" "8.35.0"
+
 "@typescript-eslint/tsconfig-utils@8.33.1":
   version "8.33.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.33.1.tgz#7836afcc097a4657a5ed56670851a450d8b70ab8"
@@ -3743,13 +3760,18 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz#d6abb1b1e9f1f1c83ac92051c8fbf2dbc4dc9f5e"
   integrity sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==
 
-"@typescript-eslint/type-utils@8.34.1":
-  version "8.34.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz#df860d8edefbfe142473ea4defb7408edb0c379e"
-  integrity sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==
+"@typescript-eslint/tsconfig-utils@8.35.0", "@typescript-eslint/tsconfig-utils@^8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz#6e05aeb999999e31d562ceb4fe144f3cbfbd670e"
+  integrity sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==
+
+"@typescript-eslint/type-utils@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz#0201eae9d83ffcc3451ef8c94f53ecfbf2319ecc"
+  integrity sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==
   dependencies:
-    "@typescript-eslint/typescript-estree" "8.34.1"
-    "@typescript-eslint/utils" "8.34.1"
+    "@typescript-eslint/typescript-estree" "8.35.0"
+    "@typescript-eslint/utils" "8.35.0"
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
@@ -3767,6 +3789,11 @@
   version "8.34.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.34.1.tgz#565a46a251580dae674dac5aafa8eb14b8322a35"
   integrity sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==
+
+"@typescript-eslint/types@8.35.0", "@typescript-eslint/types@^8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.35.0.tgz#e60d062907930e30008d796de5c4170f02618a93"
+  integrity sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==
 
 "@typescript-eslint/typescript-estree@8.16.0":
   version "8.16.0"
@@ -3814,7 +3841,33 @@
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/utils@8.34.1", "@typescript-eslint/utils@^8.0.0":
+"@typescript-eslint/typescript-estree@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz#86141e6c55b75bc1eaecc0781bd39704de14e52a"
+  integrity sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==
+  dependencies:
+    "@typescript-eslint/project-service" "8.35.0"
+    "@typescript-eslint/tsconfig-utils" "8.35.0"
+    "@typescript-eslint/types" "8.35.0"
+    "@typescript-eslint/visitor-keys" "8.35.0"
+    debug "^4.3.4"
+    fast-glob "^3.3.2"
+    is-glob "^4.0.3"
+    minimatch "^9.0.4"
+    semver "^7.6.0"
+    ts-api-utils "^2.1.0"
+
+"@typescript-eslint/utils@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.35.0.tgz#aaf0afab5ab51ea2f1897002907eacd9834606d5"
+  integrity sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/scope-manager" "8.35.0"
+    "@typescript-eslint/types" "8.35.0"
+    "@typescript-eslint/typescript-estree" "8.35.0"
+
+"@typescript-eslint/utils@^8.0.0":
   version "8.34.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.34.1.tgz#f98c9b0c5cae407e34f5131cac0f3a74347a398e"
   integrity sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==
@@ -3866,6 +3919,14 @@
   integrity sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==
   dependencies:
     "@typescript-eslint/types" "8.34.1"
+    eslint-visitor-keys "^4.2.1"
+
+"@typescript-eslint/visitor-keys@8.35.0":
+  version "8.35.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz#93e905e7f1e94d26a79771d1b1eb0024cb159dbf"
+  integrity sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==
+  dependencies:
+    "@typescript-eslint/types" "8.35.0"
     eslint-visitor-keys "^4.2.1"
 
 "@ungap/structured-clone@^1.2.0":
@@ -7204,14 +7265,14 @@ eslint-config-airbnb@19.0.4:
   dependencies:
     "@babel/eslint-parser" "7.16.5"
     "@tanstack/eslint-plugin-query" "5.74.7"
-    "@typescript-eslint/eslint-plugin" "8.34.1"
-    "@typescript-eslint/parser" "8.34.1"
+    "@typescript-eslint/eslint-plugin" "8.35.0"
+    "@typescript-eslint/parser" "8.35.0"
     eslint "8.57.0"
     eslint-config-airbnb "19.0.4"
     eslint-config-prettier "10.1.5"
     eslint-import-resolver-webpack "0.13.10"
     eslint-plugin-compat "6.0.2"
-    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-704942f5-e43f-4571-86f3-692d658cd8e1-1750660131984/node_modules/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-358969f7-fbe5-4219-a008-3f7e3327b30d-1750767161010/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.25.3"
     eslint-plugin-jest "29.0.1"
     eslint-plugin-jest-dom "5.5.0"
@@ -8708,12 +8769,12 @@ graphemer@^1.4.0:
     "@tanstack/react-query" "5.81.2"
     "@types/jquery" "3.5.32"
     "@types/react" "18.3.13"
-    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/babel-preset-graylog"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/eslint-config-graylog"
+    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-78e8edd0-db16-4e59-9189-73968300c9bf-1750767160873/node_modules/babel-preset-graylog"
+    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-78e8edd0-db16-4e59-9189-73968300c9bf-1750767160873/node_modules/eslint-config-graylog"
     formik "2.4.6"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-78e8edd0-db16-4e59-9189-73968300c9bf-1750767160873/node_modules/jest-preset-graylog"
     jquery "3.7.1"
     moment "2.30.1"
     moment-timezone "0.6.0"

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1621,20 +1621,20 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@csstools/css-parser-algorithms@^3.0.4":
+"@csstools/css-parser-algorithms@^3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.4":
   version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz#74426e93bd1c4dcab3e441f5cc7ba4fb35d94356"
-  integrity sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
-"@csstools/css-tokenizer@^3.0.3":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz#a5502c8539265fecbd873c1e395a890339f119c2"
-  integrity sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==
-
-"@csstools/media-query-list-parser@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz#e80e17eba1693fceafb8d6f2cfc68c0e7a9ab78a"
-  integrity sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==
+"@csstools/media-query-list-parser@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz#7aec77bcb89c2da80ef207e73f474ef9e1b3cdf1"
+  integrity sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==
 
 "@csstools/selector-specificity@^5.0.0":
   version "5.0.0"
@@ -2861,6 +2861,11 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.77.1.tgz#180ae89457f80e1b24f48a2f28e8eb1d348e213f"
   integrity sha512-nfxVhy4UynChMFfN4NxwI8pktV9R3Zt/ROxOAe6pdOf8CigDLn26p+ex1YW5uien26BBICLmN0dTvIELHCs5vw==
 
+"@tanstack/query-core@5.81.2":
+  version "5.81.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.81.2.tgz#4ff8cc7f07753db41aa493dcbe5413d694dddb0d"
+  integrity sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==
+
 "@tanstack/query-persist-client-core@5.77.1":
   version "5.77.1"
   resolved "https://registry.yarnpkg.com/@tanstack/query-persist-client-core/-/query-persist-client-core-5.77.1.tgz#cc9702e2687a8dd660dcf54fb250810a3594336b"
@@ -2883,12 +2888,12 @@
   dependencies:
     "@tanstack/query-persist-client-core" "5.77.1"
 
-"@tanstack/react-query@5.77.1":
-  version "5.77.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.77.1.tgz#89fb66e0fb3f6a1359cf171ca4e883e111d2a58f"
-  integrity sha512-qBwpxFg0+MZF0fICQwgvzwrVbcs7TdQlLyEd1f1dN83oeIALofCIAJHV7sPWu+BCS5tcXkG5CvOuf7yla8GYqQ==
+"@tanstack/react-query@5.81.2":
+  version "5.81.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.81.2.tgz#e4cc02102ce4d14a51440d6bcbad152dc8f140ed"
+  integrity sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==
   dependencies:
-    "@tanstack/query-core" "5.77.1"
+    "@tanstack/query-core" "5.81.2"
 
 "@testing-library/dom@9.3.4", "@testing-library/dom@>=7", "@testing-library/dom@^9.0.0":
   version "9.3.4"
@@ -5019,10 +5024,10 @@ cacache@^18.0.0:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
-cacheable@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/cacheable/-/cacheable-1.9.0.tgz#57e3565c311d66371eeb5f2070b6615d43b89711"
-  integrity sha512-8D5htMCxPDUULux9gFzv30f04Xo3wCnik0oOxKoRTPIBoqA7HtOcJ87uBhQTs3jCfZZTrUBGsYIZOgE0ZRgMAg==
+cacheable@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/cacheable/-/cacheable-1.10.0.tgz#844dc3bc299344af373b728d9f4f0906ee67c1c9"
+  integrity sha512-SSgQTAnhd7WlJXnGlIi4jJJOiHzgnM5wRMEPaXAU4kECTAMpBoYKoZ9i5zHmclIEZbxcu3j7yY/CF8DTmwIsHg==
   dependencies:
     hookified "^1.8.2"
     keyv "^5.3.3"
@@ -7206,7 +7211,7 @@ eslint-config-airbnb@19.0.4:
     eslint-config-prettier "10.1.5"
     eslint-import-resolver-webpack "0.13.10"
     eslint-plugin-compat "6.0.2"
-    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-237fa168-fcba-4c8f-9020-21d0dd234ab0-1750379581007/node_modules/eslint-plugin-graylog"
+    eslint-plugin-graylog "file:../../../../.cache/yarn/v6/npm-eslint-config-graylog-1.3.0-704942f5-e43f-4571-86f3-692d658cd8e1-1750660131984/node_modules/eslint-plugin-graylog"
     eslint-plugin-import "2.25.3"
     eslint-plugin-jest "29.0.1"
     eslint-plugin-jest-dom "5.5.0"
@@ -7823,12 +7828,12 @@ fflate@^0.4.8:
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.4.8.tgz#f90b82aefbd8ac174213abb338bd7ef848f0f5ae"
   integrity sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==
 
-file-entry-cache@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-10.1.0.tgz#54c0117fe76425e9f08a44a3a08bedde0cd93fe8"
-  integrity sha512-Et/ex6smi3wOOB+n5mek+Grf7P2AxZR5ueqRUvAAn4qkyatXi3cUC1cuQXVkX0VlzBVsN4BkWJFmY/fYiRTdww==
+file-entry-cache@^10.1.1:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-10.1.1.tgz#ca46f5c4eb22cc37e4ac30214452a59c297d2119"
+  integrity sha512-zcmsHjg2B2zjuBgjdnB+9q0+cWcgWfykIcsDkWDB4GTPtl1eXUA+gTI6sO0u01AqK3cliHryTU55/b2Ow1hfZg==
   dependencies:
-    flat-cache "^6.1.9"
+    flat-cache "^6.1.10"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -7913,14 +7918,14 @@ flat-cache@^3.0.4:
     flatted "^3.1.0"
     rimraf "^3.0.2"
 
-flat-cache@^6.1.9:
-  version "6.1.9"
-  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-6.1.9.tgz#6f512c4ab81c2057577fdb30c2f64022d43db2e7"
-  integrity sha512-DUqiKkTlAfhtl7g78IuwqYM+YqvT+as0mY+EVk6mfimy19U79pJCzDZQsnqk3Ou/T6hFXWLGbwbADzD/c8Tydg==
+flat-cache@^6.1.10:
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-6.1.10.tgz#bf388abca92c213ac55086d678b08362867d6213"
+  integrity sha512-B6/v1f0NwjxzmeOhzfXPGWpKBVA207LS7lehaVKQnFrVktcFRfkzjZZ2gwj2i1TkEUMQht7ZMJbABUT5N+V1Nw==
   dependencies:
-    cacheable "^1.9.0"
+    cacheable "^1.10.0"
     flatted "^3.3.3"
-    hookified "^1.8.2"
+    hookified "^1.9.1"
 
 flat@^5.0.2:
   version "5.0.2"
@@ -8700,15 +8705,15 @@ graphemer@^1.4.0:
   dependencies:
     "@graylog/sawmill" "2.0.24"
     "@reduxjs/toolkit" "^2.5.1"
-    "@tanstack/react-query" "5.77.1"
+    "@tanstack/react-query" "5.81.2"
     "@types/jquery" "3.5.32"
     "@types/react" "18.3.13"
-    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-a526ebd6-c680-4321-81b9-74169774ba6a-1750379580865/node_modules/babel-preset-graylog"
-    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-a526ebd6-c680-4321-81b9-74169774ba6a-1750379580865/node_modules/eslint-config-graylog"
+    babel-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/babel-preset-graylog"
+    eslint-config-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/eslint-config-graylog"
     formik "2.4.6"
     history "^5.3.0"
     html-webpack-plugin "^5.5.0"
-    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-a526ebd6-c680-4321-81b9-74169774ba6a-1750379580865/node_modules/jest-preset-graylog"
+    jest-preset-graylog "file:../../../../.cache/yarn/v6/npm-graylog-web-plugin-7.0.0-SNAPSHOT-d86ed985-a25d-4899-b6b0-fbe45191f2b7-1750660131793/node_modules/jest-preset-graylog"
     jquery "3.7.1"
     moment "2.30.1"
     moment-timezone "0.6.0"
@@ -8897,7 +8902,7 @@ hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-
   dependencies:
     react-is "^16.7.0"
 
-hookified@^1.8.2:
+hookified@^1.8.2, hookified@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/hookified/-/hookified-1.9.1.tgz#d30cb77590672a05029b7ea9adf25b71c406121d"
   integrity sha512-u3pxtGhKjcSXnGm1CX6aXS9xew535j3lkOCegbA6jdyh0BaAjTbXI4aslKstCr6zUNtoCxFGFKwjbSHdGrMB8g==
@@ -9128,7 +9133,7 @@ ignore@^7.0.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.4.tgz#a12c70d0f2607c5bf508fb65a40c75f037d7a078"
   integrity sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==
 
-ignore@^7.0.4:
+ignore@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
@@ -10635,10 +10640,10 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-known-css-properties@^0.36.0:
-  version "0.36.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.36.0.tgz#5c4365f3c9549ca2e813d2e729e6c47ef6a6cb60"
-  integrity sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==
+known-css-properties@^0.37.0:
+  version "0.37.0"
+  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.37.0.tgz#10ebe49b9dbb6638860ff8a002fb65a053f4aec5"
+  integrity sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==
 
 language-subtag-registry@^0.3.20:
   version "0.3.22"
@@ -11301,7 +11306,12 @@ nan@~2.20.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.20.0.tgz#08c5ea813dd54ed16e5bd6505bf42af4f7838ca3"
   integrity sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==
 
-nanoid@^3.3.7, nanoid@^3.3.8:
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+nanoid@^3.3.7:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
   integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
@@ -12243,12 +12253,12 @@ postcss@^8.4.31, postcss@^8.4.33:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-postcss@^8.5.3:
-  version "8.5.3"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
-  integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
+postcss@^8.5.5:
+  version "8.5.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
+  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
   dependencies:
-    nanoid "^3.3.8"
+    nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -14495,7 +14505,7 @@ styled-components@6.1.1:
   version "1.0.0"
   dependencies:
     postcss-styled-syntax "0.7.1"
-    stylelint "16.20.0"
+    stylelint "16.21.0"
     stylelint-config-recommended "16.0.0"
     stylelint-config-standard "38.0.0"
 
@@ -14511,14 +14521,14 @@ stylelint-config-standard@38.0.0:
   dependencies:
     stylelint-config-recommended "^16.0.0"
 
-stylelint@16.20.0:
-  version "16.20.0"
-  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-16.20.0.tgz#ec9eeddd49c20bbc397473505e63ad22f1639228"
-  integrity sha512-B5Myu9WRxrgKuLs3YyUXLP2H0mrbejwNxPmyADlACWwFsrL8Bmor/nTSh4OMae5sHjOz6gkSeccQH34gM4/nAw==
+stylelint@16.21.0:
+  version "16.21.0"
+  resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-16.21.0.tgz#c24050d8e67621fa2c2269c082966e2c0f6a1883"
+  integrity sha512-ki3PpJGG7xhm3WtINoWGnlvqAmbqSexoRMbEMJzlwewSIOqPRKPlq452c22xAdEJISVi80r+I7KL9GPUiwFgbg==
   dependencies:
-    "@csstools/css-parser-algorithms" "^3.0.4"
-    "@csstools/css-tokenizer" "^3.0.3"
-    "@csstools/media-query-list-parser" "^4.0.2"
+    "@csstools/css-parser-algorithms" "^3.0.5"
+    "@csstools/css-tokenizer" "^3.0.4"
+    "@csstools/media-query-list-parser" "^4.0.3"
     "@csstools/selector-specificity" "^5.0.0"
     "@dual-bundle/import-meta-resolve" "^4.1.0"
     balanced-match "^2.0.0"
@@ -14529,21 +14539,21 @@ stylelint@16.20.0:
     debug "^4.4.1"
     fast-glob "^3.3.3"
     fastest-levenshtein "^1.0.16"
-    file-entry-cache "^10.1.0"
+    file-entry-cache "^10.1.1"
     global-modules "^2.0.0"
     globby "^11.1.0"
     globjoin "^0.1.4"
     html-tags "^3.3.1"
-    ignore "^7.0.4"
+    ignore "^7.0.5"
     imurmurhash "^0.1.4"
     is-plain-object "^5.0.0"
-    known-css-properties "^0.36.0"
+    known-css-properties "^0.37.0"
     mathml-tag-names "^2.1.3"
     meow "^13.2.0"
     micromatch "^4.0.8"
     normalize-path "^3.0.0"
     picocolors "^1.1.1"
-    postcss "^8.5.3"
+    postcss "^8.5.5"
     postcss-resolve-nested-selector "^0.1.6"
     postcss-safe-parser "^7.0.1"
     postcss-selector-parser "^7.1.0"

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <commons-validator.version>1.9.0</commons-validator.version>
         <commons-io.version>2.19.0</commons-io.version>
         <disruptor.version>4.0.0</disruptor.version>
-        <error-prone.version>2.38.0</error-prone.version>
+        <error-prone.version>2.39.0</error-prone.version>
         <freemarker.version>2.3.34</freemarker.version>
         <gcs.version>2.53.1</gcs.version>
         <gelfclient.version>1.5.1</gelfclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,8 @@
         <netty-tcnative-boringssl-static.version>2.0.70.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>4.12.0</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
-        <opentelemetry.version>1.32.0</opentelemetry.version>
+        <opentelemetry.version>1.51.0</opentelemetry.version>
+        <opentelemetry-instrumentation.version>2.16.0</opentelemetry-instrumentation.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <owasp-sanitizer.version>20240325.1</owasp-sanitizer.version>
         <pkts.version>3.0.18</pkts.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1058,6 +1058,7 @@
                             -Xep:PrimitiveAtomicReference:ERROR
                             -Xep:WildcardImport:ERROR
                             -Xep:JavaDurationGetSecondsToToSeconds:ERROR
+                            -Xep:StreamResourceLeak:ERROR
                         </arg>
                     </compilerArgs>
                     <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -662,7 +662,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.9.3.0</version>
+                    <version>4.9.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>de.thetaphi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <assertj-core.version>3.27.3</assertj-core.version>
         <assertj-joda-time.version>2.2.0</assertj-joda-time.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <equalsverifier.version>4.0.2</equalsverifier.version>
+        <equalsverifier.version>4.0.3</equalsverifier.version>
         <jukito.version>1.5</jukito.version>
         <junit.version>4.13.2</junit.version>
         <junit-jupiter.version>5.12.2</junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <bouncycastle.version>1.81</bouncycastle.version>
         <caffeine.version>3.2.1</caffeine.version>
         <cef-parser.version>0.0.1.10</cef-parser.version>
-        <classgraph.version>4.8.179</classgraph.version>
+        <classgraph.version>4.8.180</classgraph.version>
         <commons-codec.version>1.18.0</commons-codec.version>
         <commons-csv.version>1.14.0</commons-csv.version>
         <commons-email.version>1.6.0</commons-email.version>


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `c102f54..3b4407c`
**Files Changed:** 70 (50 programming files)
**Programming Ratio:** 71.4%

**Commits included:**
- Do not display description column by default in saved searches overview. (#22929)
- Fixing timerange calculation for 'to' in DatePicker depending on 'from:All time' selection (#22839)
- Bump com.google.errorprone:error_prone_core from 2.38.0 to 2.39.0 (#22985)
- Bump com.github.spotbugs:spotbugs-maven-plugin from 4.9.3.0 to 4.9.3.1 (#22986)
- Enforce closing of MongoDB streams (#22808)
- Updating yarn lockfile (#22980)
- Bump io.github.classgraph:classgraph from 4.8.179 to 4.8.180 (#22973)
- Bump nl.jqno.equalsverifier:equalsverifier from 4.0.2 to 4.0.3 (#22974)
- Bump the typescript-eslint group (#22972)
- Update OpenTelemetry version to 1.51.0 (#22906)
... and 5 more commits